### PR TITLE
a bug where google-search-result links are not fixed on 'Firefox for Android'

### DIFF
--- a/data/content.js
+++ b/data/content.js
@@ -8,6 +8,7 @@ window.addEventListener("mousedown", saveLinkTarget, true);
 window.addEventListener("mousedown", restoreLinkTarget, false);
 window.addEventListener("click", interceptEvent, true);
 window.addEventListener("keydown", interceptEvent, true);
+window.addEventListener("DOMContentLoaded", fixLinks, false);
 
 function detach()
 {
@@ -17,6 +18,7 @@ function detach()
     window.removeEventListener("mousedown", restoreLinkTarget, false);
     window.removeEventListener("click", interceptEvent, true);
     window.removeEventListener("keydown", interceptEvent, true);
+    window.removeEventListener("DOMContentLoaded", fixLinks, false);
   }
   catch (e)
   {
@@ -44,6 +46,7 @@ let containerAttr = {
   "duckduckgo": ["class", "results"],
   "google-news": ["class", "content-pane-container"],
 };
+
 
 function isSearchPage(window)
 {
@@ -151,3 +154,28 @@ function interceptEvent(event)
     event.stopPropagation();
   }
 }
+
+function fixLinks()
+{
+  // fix all links on the Google Web Search for Mobile.
+  if (/google\./.test(window.location.host))
+  {
+    if (isSearchPage(window))
+    {
+      for (let link of window.document.links)
+      {
+        if (/\/\/[a-z]+\.google[^\/]+\/url\?/.exec(link.href))
+        {
+          let url = null;
+          for (let pair of link.search.substring(1).split("&"))
+          {
+            let pairarr = pair.split("=", 2);
+            if ((pairarr[0] === "q") || (pairarr[0] === "url"))
+              link.href = decodeURIComponent(pairarr[1]);
+          }
+        }
+      }
+    }
+  }
+}
+console.log("x");

--- a/tests/google_mobile_search.py
+++ b/tests/google_mobile_search.py
@@ -34,6 +34,16 @@ def assert_no_intermediate_urls(driver, method, target):
 def run(driver):
     global href
 
+    # Spoof Firefox for Mobile
+    driver.set_context(driver.CONTEXT_CHROME)
+    driver.execute_script(
+        'Cc["@mozilla.org/preferences-service;1"]' +
+        '.getService(Ci.nsIPrefService)' +
+        '.QueryInterface(Ci.nsIPrefBranch)' +
+        '.setCharPref("general.useragent.override", "Mozilla/5.0 (Mobile; rv:55.0) Gecko/55.0 Firefox/55.0");'
+    )
+    driver.set_context(driver.CONTEXT_CONTENT)
+
     # Search for site:palant.de
     driver.navigate('https://www.google.com/?gfe_rd=cr&hl=en')
     driver.wait_until(lambda: driver.find_elements('name', 'q'))
@@ -70,3 +80,13 @@ def run(driver):
     assert_no_intermediate_urls(driver, lambda: result.middle_click(), href)
     driver.close_background_tabs()
     assert_link_unchanged()
+
+    # Clear User-Agent Spoof
+    driver.set_context(driver.CONTEXT_CHROME)
+    driver.execute_script(
+        'Cc["@mozilla.org/preferences-service;1"]' +
+        '.getService(Ci.nsIPrefService)' +
+        '.QueryInterface(Ci.nsIPrefBranch)' +
+        '.clearUserPref("general.useragent.override");'
+    )
+    driver.set_context(driver.CONTEXT_CONTENT)


### PR DESCRIPTION
This add-on is also listed for mobile (Firefox for Android) but google-search-result links are not fixed.
This PR introduces a new fix feature that fixes the links on `DOMContentLoaded` under the mobile version of Google Search.

I believe that this PR resolves palant/searchlinkfix#40, palant/searchlinkfix#38 and palant/searchlinkfix#34 that you give up implementation.

Note: I've run the test on
 * Python v2.7.13 with VirtualEnv-2.7 v15.0.13
 * Node.js v6.11.1 with NPM v3.10.10
 * Firefox Developer Edition v55.0
