### PR TITLE
RFC: Open a search link in a new container tab.

### DIFF
--- a/data/background.js
+++ b/data/background.js
@@ -1,0 +1,10 @@
+browser.runtime.onMessage.addListener(async message =>  {
+    let tabs = await browser.tabs.query({
+        currentWindow: true,
+        active: true});
+    browser.tabs.create({
+        url: message.url,
+        index: tabs[0].index + 1,
+        cookieStoreId: "firefox-default"
+    });
+});

--- a/data/content.js
+++ b/data/content.js
@@ -154,5 +154,9 @@ function interceptEvent(event)
       /^\s*https?:/i.test(link.getAttribute("href")))
   {
     event.stopPropagation();
+    if (event.getModifierState("Accel")) {
+      event.preventDefault();
+      browser.runtime.sendMessage({url: link.getAttribute("href")});
+    }
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -34,5 +34,13 @@
       "run_at": "document_start",
       "js": ["data/content.js"]
     }
+  ],
+  "background": {
+    "scripts": ["data/background.js"]
+  },
+  "permissions": [
+    "http://*/*",
+    "https://*/*",
+    "cookies"
   ]
 }


### PR DESCRIPTION
This is a request for comment. This PR is not ready to be merged.

As a Firefox user, I would like to separate my Google and non-Google activities on the web.  Firefox containers appear to be a promising technology for this, if I could run all Google related domains in a "Google" container and all other domains in another container.

Configuring FF containers to run Google sites in a Google container is possible using the Mozilla provided Multi-Account Containers (MAC) plugin. Running all other domains in the non-Google container is not possible today. I considered submitting a PR to the MAC plugin to add the capability to open a CTRL-clicked link in the default container rather than in the current container. However, the initial redirect for click tracking makes that approach infeasible, as the new tab would be for a Google domain and therefore opened in my Google container.

I believe that the solution to what I'm trying to achieve requires removing Google's link tracking. Therefore, as a proof of concept,  I added a feature to searchlinkfix so that when the user opens a search results in a new tab, it's automatically opened up in the default container.

Looking for feedback, especially on the user experience and whether you think this plugin is the right place to solve what I'm trying to do.